### PR TITLE
fix: remove trace log creating req id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- remove trace log creating request id
+
 ## v2.1.1
 
 ### Fixed

--- a/logmiddleware.go
+++ b/logmiddleware.go
@@ -81,7 +81,6 @@ func getReqID(logger *logrus.Logger, headers http.Header) string {
 	}
 	// Generate a random uuid string. e.g. 16c9c1f2-c001-40d3-bbfe-48857367e7b5
 	requestID, err := uuid.NewRandom()
-	logger.WithField("requestId", requestID).Trace("generated request id")
 	if err != nil {
 		logger.WithError(err).Fatal("error generating request id")
 	}

--- a/logmiddleware_test.go
+++ b/logmiddleware_test.go
@@ -128,7 +128,7 @@ func TestLogMiddleware(t *testing.T) {
 		})
 		hook := testMockMiddlewareInvocation(handler, "", logger, "")
 
-		assert.Equal(t, len(hook.AllEntries()), 3, "Number of logs is not 4")
+		assert.Equal(t, len(hook.AllEntries()), 2, "Number of logs is not 2")
 		str := buffer.String()
 
 		for i, value := range strings.Split(strings.TrimSpace(str), "\n") {
@@ -403,9 +403,9 @@ func TestLogMiddleware(t *testing.T) {
 		hook := testMockMiddlewareInvocation(handler, "", nil, "")
 
 		entries := hook.AllEntries()
-		assert.Equal(t, len(entries), 3, "Unexpected entries length.")
+		assert.Equal(t, len(entries), 2, "Unexpected entries length.")
 
-		i := 1
+		i := 0
 		incomingRequest := entries[i]
 		incomingRequestID := logAssertions(t, incomingRequest, ExpectedLogFields{
 			Level:   logrus.TraceLevel,
@@ -444,6 +444,7 @@ func TestLogMiddleware(t *testing.T) {
 }
 
 func logAssertions(t *testing.T, logEntry *logrus.Entry, expected ExpectedLogFields) string {
+	t.Helper()
 	assert.Equal(t, logEntry.Level, expected.Level, "Unexpected level of log for log in incoming request")
 	assert.Equal(t, logEntry.Message, expected.Message, "Unexpected message of log for log in incoming request")
 	requestID := logEntry.Data[reqIDKey]


### PR DESCRIPTION
Resolves #24 

The log is not useful to understand who is the caller which do not forward the request id, and it spam a lot of logs for the health routes, for example in kubernetes environments