### PR TITLE
Add request context to logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- add context to logger in middlewares. This could be useful when logger support hooks.
+
 ## v4.0.1 - 07-09-2023
 
 ### Fixed

--- a/loggers/core/logger.go
+++ b/loggers/core/logger.go
@@ -16,8 +16,11 @@
 
 package core
 
+import "context"
+
 type Logger[T any] interface {
 	WithFields(fields map[string]any) Logger[T]
+	WithContext(ctx context.Context) Logger[T]
 	Trace(msg string)
 	Info(msg string)
 

--- a/loggers/fake/logger_test.go
+++ b/loggers/fake/logger_test.go
@@ -1,6 +1,7 @@
 package fake
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -179,4 +180,173 @@ func TestFakeLogger(t *testing.T) {
 			}, records)
 		})
 	})
+
+	t.Run("with context", func(t *testing.T) {
+		ctx := context.Background()
+		type ctxKey struct{}
+		ctx = context.WithValue(ctx, ctxKey{}, "foo")
+
+		expectedFields := map[string]any{"foo": "bar"}
+
+		t.Run("info log", func(t *testing.T) {
+			logger := GetLogger()
+
+			logger.WithContext(ctx).Info("my msg")
+
+			records := logger.OriginalLogger().AllRecords()
+			require.Len(t, records, 1)
+			require.Equal(t, []Record{
+				{
+					Level:   "info",
+					Message: "my msg",
+					Fields:  map[string]any{},
+					Context: ctx,
+				},
+			}, records)
+		})
+
+		t.Run("trace log", func(t *testing.T) {
+			logger := GetLogger()
+
+			logger.WithContext(ctx).Trace("my msg")
+
+			records := logger.OriginalLogger().AllRecords()
+			require.Len(t, records, 1)
+			require.Equal(t, []Record{
+				{
+					Level:   "trace",
+					Message: "my msg",
+					Fields:  map[string]any{},
+					Context: ctx,
+				},
+			}, records)
+		})
+
+		t.Run("with context + fields", func(t *testing.T) {
+			logger := GetLogger()
+
+			logger.WithContext(ctx).WithFields(map[string]any{"foo": "bar"}).Info("my msg")
+
+			records := logger.OriginalLogger().AllRecords()
+			require.Len(t, records, 1)
+			require.Equal(t, []Record{
+				{
+					Level:   "info",
+					Message: "my msg",
+					Fields: map[string]any{
+						"foo": "bar",
+					},
+					Context: ctx,
+				},
+			}, records)
+		})
+
+		t.Run("with fields + context", func(t *testing.T) {
+			logger := GetLogger()
+
+			logger.WithFields(expectedFields).WithContext(ctx).Info("my msg")
+
+			records := logger.OriginalLogger().AllRecords()
+			require.Len(t, records, 1)
+			require.Equal(t, []Record{
+				{
+					Level:   "info",
+					Message: "my msg",
+					Fields: map[string]any{
+						"foo": "bar",
+					},
+					Context: ctx,
+				},
+			}, records)
+		})
+
+		t.Run("more logs", func(t *testing.T) {
+			logger := GetLogger()
+
+			logger.WithFields(expectedFields).WithContext(ctx).Info("my msg")
+			logger.WithFields(map[string]any{
+				"some": "value",
+			}).Trace("some other")
+			logger.WithContext(context.Background()).WithFields(expectedFields).Info("yeah")
+
+			records := logger.OriginalLogger().AllRecords()
+			require.Len(t, records, 3)
+			require.Equal(t, []Record{
+				{
+					Level:   "info",
+					Message: "my msg",
+					Fields:  expectedFields,
+					Context: ctx,
+				},
+				{
+					Level:   "trace",
+					Message: "some other",
+					Fields: map[string]any{
+						"some": "value",
+					},
+				},
+				{
+					Level:   "info",
+					Message: "yeah",
+					Fields:  expectedFields,
+					Context: context.Background(),
+				},
+			}, records)
+		})
+
+		t.Run("more logs with separate loggers", func(t *testing.T) {
+			logger := GetLogger()
+
+			l1 := logger.WithContext(ctx)
+			l1.Info("my msg")
+			l1.WithFields(map[string]any{
+				"some": "value",
+			}).Trace("some other")
+			l1.WithFields(map[string]any{
+				"some": "value",
+			}).WithContext(context.Background()).WithFields(map[string]any{
+				"another": "value",
+			}).Info("ok")
+
+			logger.WithFields(map[string]any{
+				"a": "b",
+			}).Info("yeah")
+
+			records := logger.OriginalLogger().AllRecords()
+			require.Len(t, records, 4)
+			require.Equal(t, []Record{
+				{
+					Level:   "info",
+					Message: "my msg",
+					Context: ctx,
+					Fields:  map[string]any{},
+				},
+				{
+					Level:   "trace",
+					Message: "some other",
+					Fields: map[string]any{
+						"some": "value",
+					},
+					Context: ctx,
+				},
+				{
+					Level:   "info",
+					Message: "ok",
+					Context: context.Background(),
+					Fields: map[string]any{
+						"some":    "value",
+						"another": "value",
+					},
+				},
+				{
+					Level:   "info",
+					Message: "yeah",
+					Fields: map[string]any{
+						"a": "b",
+					},
+				},
+			}, records)
+		})
+	})
+
 }

--- a/loggers/logrus/logger.go
+++ b/loggers/logrus/logger.go
@@ -42,6 +42,10 @@ func (l *Logger) WithFields(fields map[string]any) core.Logger[*logrus.Entry] {
 	return &Logger{logger: l.logger.WithFields(logrus.Fields(fields))}
 }
 
+func (l *Logger) WithContext(ctx context.Context) core.Logger[*logrus.Entry] {
+	return &Logger{logger: l.logger.WithContext(ctx)}
+}
+
 func (l Logger) OriginalLogger() *logrus.Entry {
 	return l.logger
 }

--- a/loggers/logrus/logger_test.go
+++ b/loggers/logrus/logger_test.go
@@ -144,6 +144,117 @@ func TestLogger(t *testing.T) {
 		})
 	})
 
+	t.Run("with context", func(t *testing.T) {
+		ctx := context.Background()
+		type ctxKey struct{}
+		ctx = context.WithValue(ctx, ctxKey{}, "foo")
+
+		expectedFields := map[string]any{
+			"k1": "v1",
+			"k2": "v2",
+		}
+
+		t.Run("info log", func(t *testing.T) {
+			logrusLogger, hook := test.NewNullLogger()
+
+			logger := GetLogger(logrus.NewEntry(logrusLogger))
+
+			logger.WithContext(ctx).Info("my msg")
+
+			require.Len(t, hook.AllEntries(), 1)
+			assertLog(t, hook.LastEntry(), expectedLog{
+				Level:   "info",
+				Message: "my msg",
+				Context: ctx,
+			})
+		})
+
+		t.Run("trace log", func(t *testing.T) {
+			logrusLogger, hook := test.NewNullLogger()
+			logrusLogger.SetLevel(logrus.TraceLevel)
+
+			logger := GetLogger(logrus.NewEntry(logrusLogger))
+
+			logger.WithContext(ctx).Trace("my msg")
+
+			require.Len(t, hook.AllEntries(), 1)
+			assertLog(t, hook.LastEntry(), expectedLog{
+				Level:   "trace",
+				Message: "my msg",
+				Context: ctx,
+			})
+		})
+
+		t.Run("context + fields", func(t *testing.T) {
+			logrusLogger, hook := test.NewNullLogger()
+			logrusLogger.SetLevel(logrus.TraceLevel)
+
+			logger := GetLogger(logrus.NewEntry(logrusLogger))
+
+			logger.WithContext(ctx).WithFields(expectedFields).Info("my msg")
+
+			require.Len(t, hook.AllEntries(), 1)
+			assertLog(t, hook.LastEntry(), expectedLog{
+				Level:   "info",
+				Message: "my msg",
+				Context: ctx,
+				Fields:  expectedFields,
+			})
+		})
+
+		t.Run("fields + context", func(t *testing.T) {
+			logrusLogger, hook := test.NewNullLogger()
+			logrusLogger.SetLevel(logrus.TraceLevel)
+
+			logger := GetLogger(logrus.NewEntry(logrusLogger))
+
+			logger.WithFields(expectedFields).WithContext(ctx).Info("my msg")
+
+			require.Len(t, hook.AllEntries(), 1)
+			assertLog(t, hook.LastEntry(), expectedLog{
+				Level:   "info",
+				Message: "my msg",
+				Context: ctx,
+				Fields:  expectedFields,
+			})
+		})
+
+		t.Run("more logs", func(t *testing.T) {
+			logrusLogger, hook := test.NewNullLogger()
+			logrusLogger.SetLevel(logrus.TraceLevel)
+
+			logger := GetLogger(logrus.NewEntry(logrusLogger))
+
+			logger.WithFields(expectedFields).WithContext(ctx).Info("my msg")
+			logger.WithFields(expectedFields).Trace("some other")
+			logger.WithContext(context.Background()).WithFields(expectedFields).Info("yeah")
+			logger.Info("ok")
+
+			require.Len(t, hook.AllEntries(), 4)
+			assertLog(t, hook.AllEntries()[0], expectedLog{
+				Level:   "info",
+				Message: "my msg",
+				Fields:  expectedFields,
+				Context: ctx,
+			})
+			assertLog(t, hook.AllEntries()[1], expectedLog{
+				Level:   "trace",
+				Message: "some other",
+				Fields:  expectedFields,
+			})
+			assertLog(t, hook.AllEntries()[2], expectedLog{
+				Level:   "info",
+				Message: "yeah",
+				Fields:  expectedFields,
+				Context: context.Background(),
+			})
+			assertLog(t, hook.LastEntry(), expectedLog{
+				Level:   "info",
+				Message: "ok",
+			})
+		})
+	})
+
 	t.Run("save and retrieve from context", func(t *testing.T) {
 		nullLogger, hook := test.NewNullLogger()
 		entry := nullLogger.WithField("some", "field")
@@ -178,14 +289,20 @@ type expectedLog struct {
 	Message string
 	Level   string
 	Fields  map[string]any
+	Context context.Context
 }
 
 func assertLog(t *testing.T, logEntry *logrus.Entry, expected expectedLog) {
 	t.Helper()
 
+	if expected.Fields == nil {
+		expected.Fields = map[string]any{}
+	}
+
 	require.Equal(t, expected, expectedLog{
 		Level:   logEntry.Level.String(),
 		Message: logEntry.Message,
 		Fields:  map[string]any(logEntry.Data),
+		Context: logEntry.Context,
 	}, "Unexpected log data")
 }

--- a/middleware/fiber/fibermiddleware.go
+++ b/middleware/fiber/fibermiddleware.go
@@ -87,7 +87,7 @@ func RequestMiddlewareLogger[Logger any](logger core.Logger[Logger], excludedPre
 		start := time.Now()
 
 		requestID := utils.GetReqID(fiberLoggingContext)
-		loggerWithReqId := logger.WithFields(map[string]any{
+		loggerWithReqId := logger.WithContext(fiberCtx.UserContext()).WithFields(map[string]any{
 			"reqId": requestID,
 		})
 		ctx := glogger.WithLogger(fiberCtx.UserContext(), loggerWithReqId.OriginalLogger())

--- a/middleware/mux/muxmiddleware.go
+++ b/middleware/mux/muxmiddleware.go
@@ -75,7 +75,7 @@ func RequestMiddlewareLogger[Logger any](logger core.Logger[Logger], excludedPre
 			}
 
 			requestID := utils.GetReqID(muxLoggingContext)
-			loggerWithReqId := logger.WithFields(map[string]any{
+			loggerWithReqId := logger.WithContext(r.Context()).WithFields(map[string]any{
 				"reqId": requestID,
 			})
 			ctx := glogger.WithLogger(r.Context(), loggerWithReqId.OriginalLogger())


### PR DESCRIPTION
This PR adds context to the logger. This is useful when the logger supports hooks, for example to inject some other fields inside the logger (as the trace id for opentelemetry).