### PR TITLE
feat(mux): implement hijacker interface in response writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 !.vscode/extensions.json
 *.code-workspace
 
+# Jetbrains
+.idea
+
 # Vim
 # Swap
 [._]*.s[a-v][a-z]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- introduce support for Hijacker interface in **mux** middleware response writer
+
 ## v4.1.0 - 16-10-2023
 
 ### Added

--- a/middleware/mux/readableresponsewriter.go
+++ b/middleware/mux/readableresponsewriter.go
@@ -17,6 +17,9 @@
 package mux
 
 import (
+	"bufio"
+	"fmt"
+	"net"
 	"net/http"
 )
 
@@ -59,4 +62,13 @@ func (r *readableResponseWriter) Flush() {
 	if flusherWriter, ok := r.Writer.(http.Flusher); ok {
 		flusherWriter.Flush()
 	}
+}
+
+// Hijack func, calls the underlying ResponseWriter Hijack fn
+func (r *readableResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := r.Writer.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	}
+
+	return nil, nil, fmt.Errorf("the Hijacker interface is not supported")
 }

--- a/middleware/mux/readableresponsewriter_test.go
+++ b/middleware/mux/readableresponsewriter_test.go
@@ -17,6 +17,8 @@
 package mux
 
 import (
+	"bufio"
+	"net"
 	"net/http"
 	"testing"
 )
@@ -26,6 +28,7 @@ type ResponseWriterMock struct {
 	writeHeaderCalled bool
 	writeCalled       bool
 	flushCalled       bool
+	hijackCalled      bool
 }
 
 func (r *ResponseWriterMock) Header() http.Header {
@@ -44,6 +47,12 @@ func (r *ResponseWriterMock) Write(b []byte) (int, error) {
 
 func (r *ResponseWriterMock) Flush() {
 	r.flushCalled = true
+}
+
+func (r *ResponseWriterMock) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	r.hijackCalled = true
+
+	return nil, nil, nil
 }
 
 func TestReadableResponseWriter(t *testing.T) {
@@ -72,5 +81,10 @@ func TestReadableResponseWriter(t *testing.T) {
 	myw.Flush()
 	if !mock.flushCalled {
 		t.Errorf("mock flush not called")
+	}
+
+	_, _, err = myw.Hijack()
+	if !mock.hijackCalled || err != nil {
+		t.Errorf("mock hijack not called successfully")
 	}
 }


### PR DESCRIPTION
In this PR it is implemented the Hijacker interface on the response writer of `mux` middleware, which wraps the standard response writer.

This allows services that use this middleware to support protocol switch, such as Websocket upgrade.